### PR TITLE
Remove fa icon link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
 		<link rel="stylesheet" href="stylesheet.css"/>
 		<link rel="shortcut icon" href="favicon.ico" type="image/x-icon"/>
 		<title>Smelt: Batch Package Manager</title>
-		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 	</head>
 	
 	


### PR DESCRIPTION
It seems best that we cancel using the font-awesome icons at the bottom, we would only really be adding a link or two, but adding to the load time while the icons are imported from the CDN.