### PR TITLE
Change to manipulate the PATH

### DIFF
--- a/smelt/install.bat
+++ b/smelt/install.bat
@@ -11,9 +11,6 @@ echo.  /U              Upgrades the specified package (used to avoid overwrite p
 goto end
 :direct
 if not exist %~dp0\extension (mkdir %~dp0\extension && echo "extension" folder doesn't exist, made and terminated... && exit)
-echo Copy batch files...
-echo Copy batch files... > %~dp0\logs\install.log
-copy %~dp0\extension\*.bat %USERPROFILE% >> %~dp0\logs\install.log
 goto init
 :param
 if /I "%2" EQU "/upgrade" (goto upgrade) else (if /I "%2" EQU "/u" (goto upgrade))
@@ -23,19 +20,19 @@ powershell -Command "(New-Object Net.WebClient).DownloadFile('https://smelt-modd
 goto init
 :upgrade
 echo Deleting batch file...
-echo Deleting batch file... > %~dp0\logs\install.log
+echo Deleting batch file...> %~dp0\logs\install.log
 del %USERPROFILE%\%1.bat >> %~dp0\logs\install.log
 goto install
 :init
 echo Make init.cmd...
-echo Make init.cmd... >> %~dp0\logs\install.log
-echo @echo off > %USERPROFILE%\init.cmd
-for %%i in (%~dp0\extension\*.bat) do echo doskey %%~ni=%USERPROFILE%\%%~nxi $* >> %USERPROFILE%\init.cmd
-echo doskey sbpm=%~dp0\sbpm.bat $* >> %USERPROFILE%\init.cmd
-echo echo on >> %USERPROFILE%\init.cmd
+echo Make init.cmd...>> %~dp0\logs\install.log
+echo @echo off> %USERPROFILE%\init.cmd
+echo.set PATH=%%PATH%%;%~dp0\extension;>> %USERPROFILE%\init.cmd
+echo.doskey sbpm=%~dp0\sbpm.bat $*>>%USERPROFILE%\init.cmd
+echo echo on>> %USERPROFILE%\init.cmd
 echo Edit registry...
 echo Edit registry... >> %~dp0\logs\install.log
 reg add "HKCU\Software\Microsoft\Command Processor" /v AutoRun /t REG_EXPAND_SZ /d "%USERPROFILE%\init.cmd" /f >> %~dp0\logs\install.log
 echo Success!
-echo Success! >> %~dp0\logs\install.log
+echo Success!>> %~dp0\logs\install.log
 :end

--- a/smelt/install.bat
+++ b/smelt/install.bat
@@ -16,18 +16,18 @@ goto init
 if /I "%2" EQU "/upgrade" (goto upgrade) else (if /I "%2" EQU "/u" (goto upgrade))
 :install
 echo Downloading batch file...
-powershell -Command "(New-Object Net.WebClient).DownloadFile('https://smelt-modding.github.io/packages/%1.bat', '%USERPROFILE%\%1.bat')" > %~dp0\logs\install.log
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://smelt-modding.github.io/packages/%1.bat', '%~dp0\extension\%1.bat')" > %~dp0\logs\install.log
 goto init
 :upgrade
 echo Deleting batch file...
 echo Deleting batch file...> %~dp0\logs\install.log
-del %USERPROFILE%\%1.bat >> %~dp0\logs\install.log
+del %~dp0\extension\%1.bat >> %~dp0\logs\install.log
 goto install
 :init
 echo Make init.cmd...
 echo Make init.cmd...>> %~dp0\logs\install.log
 echo @echo off> %USERPROFILE%\init.cmd
-echo.set PATH=%%PATH%%;%~dp0\extension;>> %USERPROFILE%\init.cmd
+echo.set PATH=%%PATH%%;%~dp0\extension>> %USERPROFILE%\init.cmd
 echo.doskey sbpm=%~dp0\sbpm.bat $*>>%USERPROFILE%\init.cmd
 echo echo on>> %USERPROFILE%\init.cmd
 echo Edit registry...

--- a/smelt/sbpm.bat
+++ b/smelt/sbpm.bat
@@ -1,3 +1,3 @@
 @echo off
-call %~dp0\%1.bat %2
+call %~dp0\%1.bat %2 %3
 echo on

--- a/smelt/sbpm.bat
+++ b/smelt/sbpm.bat
@@ -1,15 +1,3 @@
 @echo off
-if /I "%1" EQU "install" (
-  call %~dp0\install.bat %2
-) else (
-  if /I "%1" EQU "uninstall" (
-    call %~dp0\uninstall.bat %2
-  ) else (
-    if /I "%1" EQU "reinstall" (
-      call %~dp0\reinstall.bat
-    ) else (
-      call %~dp0\update.cmd
-    )
-  )
-)
+call %~dp0\%1.bat %2
 echo on

--- a/smelt/uninstall.bat
+++ b/smelt/uninstall.bat
@@ -7,21 +7,21 @@ echo SBPM UNINSTALL package
 echo.
 echo.  package         Specifies the name of the package to uninstall.
 echo.
-echo This is the method to uninstall a single command, but double-clicking uninstall.bat will uninstall the entire manager
+echo This is the method to uninstall a single command, but double-clicking uninstall.bat or running SBPM UNINSTALL with no arguments will uninstall the entire manager.
 goto end
 :direct
 echo Edit registry...
-echo Edit registry... >> %~dp0\logs\uninstall.log
+echo Edit registry...>> %~dp0\logs\uninstall.log
 reg delete "HKCU\Software\Microsoft\Command Processor" /v AutoRun /f >> %~dp0\logs\uninstall.log
 echo Delete batch file...
-echo Delete batch file... > %~dp0\logs\uninstall.log
+echo Delete batch file...> %~dp0\logs\uninstall.log
 del %USERPROFILE%\init.cmd >> %~dp0\logs\uninstall.log
 echo Success!
-echo Success! >> %~dp0\logs\uninstall.log
+echo Success!>> %~dp0\logs\uninstall.log
 goto end
 :param
 echo Delete batch file...
-echo Delete batch file... > %~dp0\logs\uninstall.log
-del %USERPROFILE%\%1.bat >> %~dp0\logs\uninstall.log
+echo Delete batch file...> %~dp0\logs\uninstall.log
+del %~dp0\extension\%1.bat >> %~dp0\logs\uninstall.log
 goto end
 :end

--- a/smelt/uninstall.bat
+++ b/smelt/uninstall.bat
@@ -13,10 +13,9 @@ goto end
 echo Edit registry...
 echo Edit registry... >> %~dp0\logs\uninstall.log
 reg delete "HKCU\Software\Microsoft\Command Processor" /v AutoRun /f >> %~dp0\logs\uninstall.log
-echo Delete batch files...
-echo Delete batch files... > %~dp0\logs\uninstall.log
+echo Delete batch file...
+echo Delete batch file... > %~dp0\logs\uninstall.log
 del %USERPROFILE%\init.cmd >> %~dp0\logs\uninstall.log
-del %USERPROFILE%\*.bat >> %~dp0\logs\uninstall.log
 echo Success!
 echo Success! >> %~dp0\logs\uninstall.log
 goto end


### PR DESCRIPTION
### Changes
Previously, new commands would be installed by copying them to `%USERPROFILE%` and manually `doskey`ing them. Now there is only one file: `%USERPROFILE%\init.cmd` that simply adds the `extension` directory to the PATH on startup and `doskey`s `sbpm.bat` instead - much more elegant.
Besides this, `sbpm.bat` previously used a switch for the subcommand - now it simply calls the corresponding batch file.
Finally, uninstalling no longer has to remove the userprofile batch files.

### Test coverage
Tested locally on Windows 8; will do QA on Win10 post-merge.

### Note
Previously I said this was a breaking change - it isn't, when updating it fully uninstalls everything before downloading the new version :D